### PR TITLE
fix(ci): use real action SHAs for the docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,15 +175,15 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@318604b99d75b7a1c2f001c95dffd99a30d59ae0 # v5.10.0
+      - uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         id: meta
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.service }}
@@ -193,7 +193,7 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
-      - uses: docker/build-push-action@2634353a5390a7eaa5dd03de08750dd1ce86a290 # v6.19.0
+      - uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         id: build
         with:
           context: .
@@ -206,7 +206,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,scope=${{ matrix.service }},mode=max
 
-      - uses: sigstore/cosign-installer@39afb6f9e23b8a93a72ee79b6cabd47e91510bf6 # v3.10.0
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image (keyless OIDC)
         env:


### PR DESCRIPTION
## Summary

PR #31 introduced the new `docker` CI job for cosign keyless OIDC + GHCR push, but the SHAs pinned for `docker/build-push-action`, `docker/metadata-action`, and `sigstore/cosign-installer` were not real commits. The post-merge run failed at "Set up job" on both matrix legs with `Unable to resolve action … unable to find version`.

Updated all five docker-related actions to verified latest stable SHAs (via `gh api repos/<o>/<r>/git/refs/tags/<tag>`):

| Action | New SHA | Tag |
|---|---|---|
| docker/setup-buildx-action | `4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd` | v4.0.0 |
| docker/login-action | `4907a6ddec9925e35a0a9e82d7399ccc52663121` | v4.1.0 |
| docker/metadata-action | `030e881283bb7a6894de51c315a6bfe6a94e05cf` | v6.0.0 |
| docker/build-push-action | `bcafcacb16a39f128d818304e6c9c0c18556b85f` | v7.1.0 |
| sigstore/cosign-installer | `6f9f17788090df1f26f669e9d70d6ae9567deba6` | v4.1.2 |

## Test plan

- [ ] Watch GitHub Actions on this PR (the `docker` job stays skipped on the PR — it only fires on push to main). Confirm the rest of the gates (changes, static-check, build, test, image-scan, e2e, e2e-kind, ci-pass) still pass.
- [ ] After merge: confirm the post-merge `docker` job (matrix over `[producer, consumer]`) now resolves all actions, builds + pushes signed images to `ghcr.io/AndriyKalashnykov/dapr-dotnet-pub-sub/{producer,consumer}`, and the cosign verify recipe in README §"Verifying signed images" works.