### PR TITLE
docs: e2e asserts both producer AND consumer traces (stale after #38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Traces come from **two layers**, both exporting to the same [Jaeger v2](https://
 | Compose (`make e2e`) | `jaeger:4317` | <http://localhost:16686> |
 | KinD (`make kind-up`) | `jaeger.dapr-pubsub.svc.cluster.local:4317` | `kubectl --context=kind-dapr-pubsub -n dapr-pubsub port-forward svc/jaeger 16686:16686` → <http://localhost:16686> |
 
-The Dapr Configuration CRD (`compose/components/config.yaml` for Compose, `k8s/config.yaml` for K8s) selects the sidecar OTLP exporter with 100% sampling; pods opt in via the `dapr.io/config: tracing` annotation (K8s) or daprd's `--config /components/config.yaml` flag (Compose). The `make e2e`/`make e2e-kind` harnesses assert a real `/send` produces a `producer` trace (two-stage `/api/services` + `/api/traces` check).
+The Dapr Configuration CRD (`compose/components/config.yaml` for Compose, `k8s/config.yaml` for K8s) selects the sidecar OTLP exporter with 100% sampling; pods opt in via the `dapr.io/config: tracing` annotation (K8s) or daprd's `--config /components/config.yaml` flag (Compose). The `make e2e`/`make e2e-kind` harnesses assert that a real `/send` lands both a `producer` trace (the publish) and a `consumer` trace (the delivered-message handler) in Jaeger — a two-stage `/api/services` + `/api/traces` check per service.
 
 ### Infrastructure
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -100,7 +100,7 @@ Non-obvious decisions and traps documented for the next contributor. Each entry 
 
 **Rejected.** Relying solely on the Dapr sidecar's tracing.
 
-**Failure mode.** Dapr only traces operations that flow through the sidecar (service-invocation, pub/sub). A direct request to the app's own HTTP endpoint (`POST /send`) never enters the sidecar's traced ingress, so it produced **zero** spans — the app's actual entry point was untraced. Empirically: 13 `/send` calls landed no app spans; a sidecar-API publish landed spans. App-side OTel traces the real `/send` and handler endpoints; the e2e (`scripts/e2e-*.sh`) drives the real `/send` and asserts a `producer` trace lands in Jaeger (two-stage `/api/services` + `/api/traces` check).
+**Failure mode.** Dapr only traces operations that flow through the sidecar (service-invocation, pub/sub). A direct request to the app's own HTTP endpoint (`POST /send`) never enters the sidecar's traced ingress, so it produced **zero** spans — the app's actual entry point was untraced. Empirically: 13 `/send` calls landed no app spans; a sidecar-API publish landed spans. App-side OTel traces the real `/send` and handler endpoints; the e2e (`scripts/e2e-*.sh`) drives the real `/send` and asserts both the `producer` trace (the publish) and the `consumer` trace (the delivered-message handler) land in Jaeger (two-stage `/api/services` + `/api/traces` check per service).
 
 **Reproducing.** Unset `OTEL_EXPORTER_OTLP_ENDPOINT` on the producer, `make e2e`; the OTel trace assertion fails (no `producer` service in Jaeger from the app path).
 


### PR DESCRIPTION
Self-review-bias closing-audit follow-up: PR #37's prose said the e2e asserts "a `producer` trace"; PR #38 added the **consumer**-trace assertion but left the README §Observability line and ADR-011 describing only the producer. Updates both to reflect that the harness now asserts **both** the `producer` (publish) and `consumer` (delivered-message handler) traces land in Jaeger. Docs-only (README + docs/decisions.md), excluded from CI code jobs by the `changes` paths-filter.